### PR TITLE
Space between elements and logged in user name and email and share param between steps

### DIFF
--- a/DocuSign.MyAPI.Domain/Parameter.cs
+++ b/DocuSign.MyAPI.Domain/Parameter.cs
@@ -19,7 +19,9 @@ namespace DocuSign.MyAPI.Domain
         public string ResponseParameterPath { get; set; }
 
         public string Source { get; set; }
-        
+
         public string Error { get; set; }
+
+        public string isFromUi { get; set; }
     }
 }

--- a/DocuSign.MyAPI.Domain/StepParameters.cs
+++ b/DocuSign.MyAPI.Domain/StepParameters.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace DocuSign.MyAPI.Domain
+{
+    public class StepParameterValue
+    {
+        [JsonRequired]
+        public string Name { get; set; }
+
+        [JsonRequired]
+        public string Value { get; set; }
+    }
+
+    public class StepParameters
+    {
+        [JsonRequired]
+        public string StepName { get; set; }
+
+        [JsonRequired]
+        public StepParameterValue[] Parameters { get; set; }
+    }
+}

--- a/DocuSign.MyAPI/ClientApp/src/app/header/header.component.html
+++ b/DocuSign.MyAPI/ClientApp/src/app/header/header.component.html
@@ -54,15 +54,15 @@
             </a>
           </li>
           <li class="header__menu-item">
-            <a
-            class="text"
+            <p
+            class="header__menu-item-text"
             color="primary"
             *ngIf="isLoggedIn | async"
           >
             {{loggedUserName | async}}
             <br>
             {{loggedEmail | async}}
-          </a>
+          </p>
           </li>
         </ul>
       </nav>

--- a/DocuSign.MyAPI/ClientApp/src/app/header/header.component.html
+++ b/DocuSign.MyAPI/ClientApp/src/app/header/header.component.html
@@ -53,6 +53,17 @@
               >
             </a>
           </li>
+          <li class="header__menu-item">
+            <a
+            class="text"
+            color="primary"
+            *ngIf="isLoggedIn | async"
+          >
+            {{loggedUserName | async}}
+            <br>
+            {{loggedEmail | async}}
+          </a>
+          </li>
         </ul>
       </nav>
     </div>

--- a/DocuSign.MyAPI/ClientApp/src/app/header/header.component.scss
+++ b/DocuSign.MyAPI/ClientApp/src/app/header/header.component.scss
@@ -27,9 +27,9 @@
         }
       }
 
-      &.text{
-        color: $primary;
+      &-text{
         border: 0px;
+        font-weight: bold;
       }
     }
 

--- a/DocuSign.MyAPI/ClientApp/src/app/header/header.component.scss
+++ b/DocuSign.MyAPI/ClientApp/src/app/header/header.component.scss
@@ -26,6 +26,11 @@
           color: $primary;
         }
       }
+
+      &.text{
+        color: $primary;
+        border: 0px;
+      }
     }
 
     &-link {

--- a/DocuSign.MyAPI/ClientApp/src/app/header/header.component.ts
+++ b/DocuSign.MyAPI/ClientApp/src/app/header/header.component.ts
@@ -27,6 +27,14 @@ export class AppHeaderComponent implements OnInit {
     return this.accountService.isLoggedIn();
   }
 
+  get loggedUserName(): Observable<string> {
+    return this.accountService.currentUserName;
+  }
+
+  get loggedEmail(): Observable<string> {
+    return this.accountService.currentEmail;
+  }
+
   logout(): void {
     this.accountService.logout();
   }

--- a/DocuSign.MyAPI/ClientApp/src/app/scenario/execute-scenario/execute-scenario.component.ts
+++ b/DocuSign.MyAPI/ClientApp/src/app/scenario/execute-scenario/execute-scenario.component.ts
@@ -14,6 +14,8 @@ import {
 } from '@angular/forms';
 import { ErrorStateMatcher } from '@angular/material/core';
 import { IScenarioExecutionResult } from '../models/scenario-execution-result';
+import { NotificationService } from 'src/app/services/notification-service';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-execute-scenario',
@@ -50,7 +52,11 @@ export class ExecuteScenarioComponent {
     @Inject(ExecutionResultService)
     private executionResultService: ExecutionResultService,
     @Inject(ParametersPromptNotificationService)
-    private parametersPromptNotificationService: ParametersPromptNotificationService
+    private parametersPromptNotificationService: ParametersPromptNotificationService,
+    @Inject (NotificationService)
+    private notificationService: NotificationService,
+    @Inject (TranslateService)
+    private translateService: TranslateService
   ) {}
 
   onSubmitCallback = (args: any): void => {
@@ -70,6 +76,13 @@ export class ExecuteScenarioComponent {
 
           if (!this.outputResults) {
             this.executionResultService.addResults(results);
+          }
+          else {
+            this.translateService
+            .get('EXECUTE.SCENARIO.EXECUTION_COMPLETE')
+            .subscribe((res: string) => {
+              this.notificationService.showInfo(res);
+            });
           }
 
           this.executeEvent.emit(!this.outputResults);

--- a/DocuSign.MyAPI/ClientApp/src/app/scenario/models/execute-scenario.ts
+++ b/DocuSign.MyAPI/ClientApp/src/app/scenario/models/execute-scenario.ts
@@ -9,9 +9,20 @@ export interface IExecuteScenarioStep {
   stepName: string;
   parameters: string;
   previousStepResponses: IStepResponse[];
+  previousStepParameters: IStepParameters[];
 }
 
 export interface IStepResponse {
   stepName: string;
   response: string;
+}
+
+export interface IStepParameterValue {
+  name: string;
+  value: any;
+}
+
+export interface IStepParameters {
+  stepName: string;
+  parameters: IStepParameterValue[];
 }

--- a/DocuSign.MyAPI/ClientApp/src/app/scenario/models/step-info.ts
+++ b/DocuSign.MyAPI/ClientApp/src/app/scenario/models/step-info.ts
@@ -19,4 +19,5 @@ export interface IParameter {
   description: string;
   responseParameterPath: string;
   source: string;
+  isFromUi: boolean;
 }

--- a/DocuSign.MyAPI/ClientApp/src/app/scenario/scenario.component.html
+++ b/DocuSign.MyAPI/ClientApp/src/app/scenario/scenario.component.html
@@ -32,6 +32,7 @@
   <mat-step
     *ngFor="let step of scenario.steps; let i = index"
     [completed]="step.completed"
+    [aria-labelledby]="isStepDisabled(scenario.steps, i - 1) ? 'disabled' : ''"
   >
     <ng-template matStepLabel>
       <div class="step__header">
@@ -48,9 +49,11 @@
     <ng-template matStepContent>
       <app-step
         [scenarioId]="scenarioId"
+        [scenarioTitle]="scenario.title"
         [step]="step"
         [stepIndex]="i"
         (executeEvent)="onExecuteEvent($event)"
+        (navigateToMain)="navigateToStep(stepper, 0)"
       ></app-step>
     </ng-template>
   </mat-step>

--- a/DocuSign.MyAPI/ClientApp/src/app/scenario/scenario.component.ts
+++ b/DocuSign.MyAPI/ClientApp/src/app/scenario/scenario.component.ts
@@ -10,6 +10,8 @@ import { ScenarioService } from './services/scenario-service';
 import { IScenarioInfo } from './models/scenario-info';
 import { StepperSelectionEvent } from '@angular/cdk/stepper';
 import { AccountService } from './../services/account-service';
+import { MatStepper } from '@angular/material/stepper';
+import { IScenarioStep } from './models/scenario-step';
 
 @Component({
   selector: 'app-scenario',
@@ -81,4 +83,14 @@ export class ScenarioComponent implements OnInit, AfterViewChecked {
   onExecuteEvent = (arg: boolean): void => {
     this.isResultsShown = arg;
   };
+
+  navigateToStep = (stepper: MatStepper, stepNumber: number): void => {
+    stepper.selectedIndex = stepNumber;
+  }
+
+  isStepDisabled = (steps: IScenarioStep[], stepNumber: number): boolean => {
+    const firstUncompletedStep = steps.findIndex((step) => !step.completed);
+
+    return firstUncompletedStep !== -1 && firstUncompletedStep <= stepNumber;
+  }
 }

--- a/DocuSign.MyAPI/ClientApp/src/app/scenario/step/step.component.html
+++ b/DocuSign.MyAPI/ClientApp/src/app/scenario/step/step.component.html
@@ -6,6 +6,12 @@
           <a [routerLink]="['/']" class="breadcrumbs__link" translate>HOME</a>
         </li>
         <li class="breadcrumbs__item">
+          <a [routerLink]="['/scenario/' + scenarioId]"
+             class="breadcrumbs__link"
+             [innerHTML]="scenarioTitle"
+             (click)="openMain()"></a>
+        </li>
+        <li class="breadcrumbs__item">
           <a [routerLink]="['/']"
              class="breadcrumbs__link breadcrumbs__link--disabled"
              [innerHTML]="step.title"></a>

--- a/DocuSign.MyAPI/ClientApp/src/app/scenario/step/step.component.scss
+++ b/DocuSign.MyAPI/ClientApp/src/app/scenario/step/step.component.scss
@@ -72,6 +72,7 @@
   }
 }
 .url {
+  margin-top: 24px;
   span {
     padding-right: 5px;
   }

--- a/DocuSign.MyAPI/ClientApp/src/app/scenario/step/step.component.ts
+++ b/DocuSign.MyAPI/ClientApp/src/app/scenario/step/step.component.ts
@@ -36,7 +36,9 @@ export class StepComponent implements OnInit {
   parametersPromptComponent!: ParametersPromptComponent;
   @Input() step!: IScenarioStep;
   @Input() scenarioId!: number;
+  @Input() scenarioTitle!: string;
   @Input() stepIndex!: number;
+  @Output() navigateToMain = new EventEmitter<void>();
   @Output() executeEvent = new EventEmitter<boolean>();
   pathParam: Dictionary<string> = {};
 
@@ -289,6 +291,10 @@ export class StepComponent implements OnInit {
 
   executeStep() {
     this.parametersPromptComponent.onSubmit();
+  }
+
+  openMain() {
+    this.navigateToMain.emit();
   }
 
   get isLoggedIn(): Observable<boolean> {

--- a/DocuSign.MyAPI/ClientApp/src/app/scenario/step/step.component.ts
+++ b/DocuSign.MyAPI/ClientApp/src/app/scenario/step/step.component.ts
@@ -18,6 +18,8 @@ import { ParametersPromptNotificationService } from '../services/parameters-prom
 import { IParameterValue } from '../models/parameter-prompt';
 import {
   IExecuteScenarioStep,
+  IStepParameterValue,
+  IStepParameters,
   IStepResponse,
 } from '../models/execute-scenario';
 import { IScenarioExecutionResult } from '../models/scenario-execution-result';
@@ -216,12 +218,37 @@ export class StepComponent implements OnInit {
             <IStepResponse>{ stepName: item.stepName, response: item.response }
         );
     }
+    var previousParameters: IStepParameters[] = [];
+    if (this.stepIndex > 0) {
+      previousParameters = this.localStorageService.getStepParameters(this.scenarioId);
+    }
+
     const model: IExecuteScenarioStep = {
       scenarioNumber: this.scenarioId,
       stepName: this.stepInfo.name,
       parameters: args === null ? '' : JSON.stringify(args),
       previousStepResponses: previousResponses,
+      previousStepParameters: previousParameters,
     };
+
+    var currentParametersValue: IStepParameterValue[] = [];
+    let parameters;
+    if (typeof args === 'object' && args !== null) {
+      parameters = args;
+    } else if (args !== null && args.trim() !== "") {
+      parameters = JSON.parse(args);
+    }
+
+    if (parameters) {
+      for (const [name, value] of Object.entries(parameters)) {
+        currentParametersValue.push({ name, value });
+      }
+      var currentStepParameters: IStepParameters = {
+        stepName: this.stepInfo.name,
+        parameters: currentParametersValue,
+      };
+      this.localStorageService.setStepParameters(this.scenarioId, [...previousParameters, currentStepParameters]);
+    }
 
     this.scenarioService
       .executeScenarioStep(model)

--- a/DocuSign.MyAPI/ClientApp/src/app/services/account-service.ts
+++ b/DocuSign.MyAPI/ClientApp/src/app/services/account-service.ts
@@ -6,16 +6,26 @@ import { map } from 'rxjs/operators';
 @Injectable()
 export class AccountService {
   accountId: string = '';
+  userName: string = '';
+  email: string = '';
   accountReceived: boolean = false;
   accountId$ = new BehaviorSubject(this.accountId);
+  userName$ = new BehaviorSubject(this.userName);
+  email$ = new BehaviorSubject(this.email);
   logoutActions$: Observable<any>[] = new Array();
 
   constructor(private http: HttpClient) {
-    this.getAccountId().subscribe(
-      (account) => {
-        this.accountId = account.id;
-        this.accountId$.next(account.id);
+    this.getAccountInfo().subscribe(
+      (info) => {
+        this.accountId = info.id;
+        this.accountId$.next(info.id);
         this.accountReceived = true;
+
+        this.userName = info.name;
+        this.userName$.next(info.name);
+
+        this.email = info.email;
+        this.email$.next(info.email);
 
         return this.accountId.length > 0;
       },
@@ -33,7 +43,15 @@ export class AccountService {
     return this.accountId$;
   }
 
-  private getAccountId(): Observable<any> {
+  get currentUserName(): Observable<string> {
+    return this.userName$;
+  }
+
+  get currentEmail(): Observable<string> {
+    return this.email$;
+  }
+
+  private getAccountInfo(): Observable<any> {
     return this.http.get('api/account', this.httpOptions);
   }
 

--- a/DocuSign.MyAPI/ClientApp/src/app/services/local-storage.service.ts
+++ b/DocuSign.MyAPI/ClientApp/src/app/services/local-storage.service.ts
@@ -30,6 +30,14 @@ export class LocalStorageService {
     }
   }
 
+  setItem(name: string, value: string){
+    localStorage.setItem(name, value);
+  }
+
+  getItem(name: string): string | null {
+    return localStorage.getItem(name);
+  }
+
   clearStorage() {
     this.setResults([]);
   }

--- a/DocuSign.MyAPI/ClientApp/src/app/services/local-storage.service.ts
+++ b/DocuSign.MyAPI/ClientApp/src/app/services/local-storage.service.ts
@@ -3,6 +3,7 @@ import { defer, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { IScenarioExecutionResult } from '../scenario/models/scenario-execution-result';
 import { AccountService } from '../services/account-service';
+import { IStepParameters } from '../scenario/models/execute-scenario';
 
 @Injectable()
 export class LocalStorageService {
@@ -28,6 +29,19 @@ export class LocalStorageService {
     if (this.accountId !== undefined && this.accountId.length > 0) {
       localStorage.setItem(this.accountId, JSON.stringify(results));
     }
+  }
+
+  setStepParameters(scenarioNumber: number, stepParameters: IStepParameters[]) {
+    localStorage.setItem(scenarioNumber + "_parameters", JSON.stringify(stepParameters));
+  }
+
+  getStepParameters(scenarioNumber: number): IStepParameters[] {
+    let stepParameters: IStepParameters[] = [];
+    const item = localStorage.getItem(scenarioNumber + "_parameters");
+    if (item !== null) {
+      stepParameters = JSON.parse(item);
+    }
+    return stepParameters;
   }
 
   setItem(name: string, value: string){

--- a/DocuSign.MyAPI/ClientApp/src/assets/i18n/en.json
+++ b/DocuSign.MyAPI/ClientApp/src/assets/i18n/en.json
@@ -50,7 +50,8 @@
       "ITERATIONS": "Number of iterations",
       "LIMITATION": "The scenario may be executed up to 10 times.",
       "DONT_SHOW": "Execute without generating API call execution log",
-      "ITERATIONS_VALIDATION_MESSAGE": "Please enter a number from 1 to 10"
+      "ITERATIONS_VALIDATION_MESSAGE": "Please enter a number from 1 to 10",
+      "EXECUTION_COMPLETE": "Execution complete"
     },
 
     "STEP": {

--- a/DocuSign.MyAPI/ClientApp/src/styles/components/_breadcrumbs.scss
+++ b/DocuSign.MyAPI/ClientApp/src/styles/components/_breadcrumbs.scss
@@ -3,6 +3,8 @@
       @extend %list-reset;
       display: flex;
       align-items: center;
+      display: flex;
+      flex-wrap: wrap;
     }
   
     &__link {
@@ -11,6 +13,7 @@
       font-weight: $font-weight-black;
       color: $body-60;
       text-decoration: none;
+      white-space: nowrap;
   
       &::after {
         display: inline-block;

--- a/DocuSign.MyAPI/ClientApp/src/styles/components/_mat-stepper.scss
+++ b/DocuSign.MyAPI/ClientApp/src/styles/components/_mat-stepper.scss
@@ -146,4 +146,9 @@
       height: 100%;
     }
   }
+
+  ::ng-deep .mat-step-header[aria-labelledby="disabled"] {
+    pointer-events: none !important;
+    cursor: default;
+  }
 }

--- a/DocuSign.MyAPI/Controllers/AccountController.cs
+++ b/DocuSign.MyAPI/Controllers/AccountController.cs
@@ -12,8 +12,15 @@ namespace DocuSign.MyAPI.Controllers
         public async Task<ActionResult<String>> GetAccountId()
         {
             var accountId = HttpContext.User.FindFirst("accountId");
+            var name = HttpContext.User.FindFirst("name");
+            var email = HttpContext.User.FindFirst("email");
 
-            return Ok(new { id = accountId == null ? string.Empty : accountId.Value });
+            return Ok(new
+            {
+                id = accountId == null ? string.Empty : accountId.Value,
+                name = name == null ? String.Empty : name.Value,
+                email = email == null ? String.Empty : email.Value
+            });
         }
 
         [HttpGet]

--- a/DocuSign.MyAPI/Controllers/ScenariosController.cs
+++ b/DocuSign.MyAPI/Controllers/ScenariosController.cs
@@ -78,7 +78,7 @@ public class ScenariosController : ControllerBase
     {
         try
         {
-            var response = await _executeScenarioService.ExecuteScenarioStep(model.ScenarioNumber, model.StepName, model.Parameters, model.PreviousStepResponses);
+            var response = await _executeScenarioService.ExecuteScenarioStep(model.ScenarioNumber, model.StepName, model.Parameters, model.PreviousStepResponses, model.PreviousStepParameters);
 
             return Ok(response);
         }

--- a/DocuSign.MyAPI/Models/ExecuteScenarioStepModel.cs
+++ b/DocuSign.MyAPI/Models/ExecuteScenarioStepModel.cs
@@ -1,9 +1,12 @@
-﻿namespace DocuSign.MyAPI.Models
+﻿using DocuSign.MyAPI.Domain;
+
+namespace DocuSign.MyAPI.Models
 {
     public class ExecuteScenarioStepModel : ExecuteScenarioModel
     {
         public string StepName { get; set; }
 
         public StepResponse[] PreviousStepResponses { get; set; }
+        public StepParameters[] PreviousStepParameters { get; set; }
     }
 }

--- a/DocuSign.MyAPI/Models/UserAccount.cs
+++ b/DocuSign.MyAPI/Models/UserAccount.cs
@@ -6,5 +6,8 @@ namespace DocuSign.MyAPI.Models
     {
         [JsonPropertyName("account_id")]
         public string Id { get; set; }
+
+        [JsonPropertyName("is_default")]
+        public bool IsDefault { get; set; }
     }
 }

--- a/DocuSign.MyAPI/Models/UserInfo.cs
+++ b/DocuSign.MyAPI/Models/UserInfo.cs
@@ -6,5 +6,11 @@ namespace DocuSign.MyAPI.Models
     {
         [JsonPropertyName("accounts")]
         public IEnumerable<UserAccount> Accounts { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
     }
 }

--- a/DocuSign.MyAPI/Program.cs
+++ b/DocuSign.MyAPI/Program.cs
@@ -87,6 +87,8 @@ builder.Services.AddAuthentication(options =>
             var user = JsonSerializer.Deserialize<UserInfo>(await response.Content.ReadAsStringAsync());
 
             context.Identity.AddClaim(new Claim("accountId", user.Accounts.First().Id, ClaimValueTypes.String));
+            context.Identity.AddClaim(new Claim("email", user.Email, ClaimValueTypes.String));
+            context.Identity.AddClaim(new Claim("name", user.Name, ClaimValueTypes.String));
         }
     };
 })

--- a/DocuSign.MyAPI/Program.cs
+++ b/DocuSign.MyAPI/Program.cs
@@ -85,8 +85,9 @@ builder.Services.AddAuthentication(options =>
             response.EnsureSuccessStatusCode();
 
             var user = JsonSerializer.Deserialize<UserInfo>(await response.Content.ReadAsStringAsync());
+            var account = user.Accounts.FirstOrDefault(acc => acc.IsDefault);
 
-            context.Identity.AddClaim(new Claim("accountId", user.Accounts.First().Id, ClaimValueTypes.String));
+            context.Identity.AddClaim(new Claim("accountId", account.Id, ClaimValueTypes.String));
             context.Identity.AddClaim(new Claim("email", user.Email, ClaimValueTypes.String));
             context.Identity.AddClaim(new Claim("name", user.Name, ClaimValueTypes.String));
         }

--- a/DocuSign.MyAPI/Services/IExecuteScenarioService.cs
+++ b/DocuSign.MyAPI/Services/IExecuteScenarioService.cs
@@ -1,4 +1,5 @@
-﻿using DocuSign.MyAPI.Models;
+﻿using DocuSign.MyAPI.Domain;
+using DocuSign.MyAPI.Models;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DocuSign.MyAPI.Tests")]
@@ -7,6 +8,6 @@ namespace DocuSign.MyAPI.Services
     public interface IExecuteScenarioService
     {
         Task<IList<ExecutionResponse>> ExecuteScenario(int scenarioNumber, string requestParameters, int iterationsCount);
-        Task<ExecutionResponse> ExecuteScenarioStep(int scenarioNumber, string stepName, string parameters, StepResponse[] previouseStepResponse);
+        Task<ExecutionResponse> ExecuteScenarioStep(int scenarioNumber, string stepName, string parameters, StepResponse[] previouseStepResponse, StepParameters[] previousStepParameters);
     }
 }

--- a/DocuSign.MyAPI/Services/RandomGenerator.cs
+++ b/DocuSign.MyAPI/Services/RandomGenerator.cs
@@ -11,7 +11,7 @@
 
         public int Generate()
         {
-            return _random.Next(1, 100);
+            return _random.Next(1, 1000);
         }
     }
 }


### PR DESCRIPTION
Display logged in account name and email address.
Fix vertical space on step page with no Parameters section.
Allow UI entered parameters to be passed between steps.
